### PR TITLE
Prevent double-decode of url param. See #9 and #10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test/tmp/*
 node_modules
 .idea
 .DS_Store
+*.swp

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -8,12 +8,13 @@ var ImageMagick = module.exports = function(config, logger) {
 
   this.config = config
   this.config.timeouts = this.config.timeouts || {}
+  this.config.tmpPathRoot = this.config.tmpPathRoot || '/tmp/node-image-magick'
 
   this.logger = logger || { log: function(){} }
 }
 
 ImageMagick.Templates = {
-  tmpPath: "/tmp/node-image-magick/%{dir}/%{file}",
+  tmpPath: "%{tmpPathRoot}/%{dir}/%{file}",
 
   downloadCmd: "curl --create-dirs -sf '%{source}' -o '%{target}'",
   identifyCmd: "identify -format %m '%{file}'",
@@ -149,7 +150,7 @@ ImageMagick.prototype._localizeSource = function(source, callback) {
   }
 
   if(source.indexOf("http") == 0) {
-    var tmpfile = ImageMagick.Templates.get('tmpPath', { dir: Date.now(), file: this._random(9999) })
+    var tmpfile = ImageMagick.Templates.get('tmpPath', { tmpPathRoot: this.config.tmpPathRoot, dir: Date.now(), file: this._random(9999) })
 
     this._downloadSource(source, tmpfile, function(err, stdout, stderr) {
       if(err && err.killed)
@@ -164,9 +165,10 @@ ImageMagick.prototype._localizeSource = function(source, callback) {
 
 ImageMagick.prototype._getTempfile = function(source, callback) {
   var self = this
+    , tmpPathRoot = this.config.tmpPathRoot
 
   this._getMimeType(source, function(mimeType) {
-    var tmpfile = ImageMagick.Templates.get('tmpPath', { dir: Date.now(), file: self._random(9999) + '.' + mimeType })
+    var tmpfile = ImageMagick.Templates.get('tmpPath', { tmpPathRoot: tmpPathRoot, dir: Date.now(), file: self._random(9999) + '.' + mimeType })
     self.execute("mkdir -p " + path.dirname(tmpfile), {}, function() { callback(tmpfile) })
   })
 }

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -156,7 +156,7 @@ ImageMagick.prototype._createTmpPath = function(rand) {
          '/' + digest.slice(30, 33) +
          '/' + digest.slice(33, 36) +
          '/' + digest.slice(36, 39) +
-         '/' + digest.slice(39) +
+         '/' + digest.slice(39)
 }
 
 ImageMagick.prototype._downloadSource = function(source, target, callback) {
@@ -176,12 +176,17 @@ ImageMagick.prototype._localizeSource = function(source, tmpPath, callback) {
   if(source.indexOf("http") == 0) {
     var tmpfile = ImageMagick.Templates.get('tmpPath', { dir: tmpPath, file: path.basename(source, path.extname(source)) + '.src' })
 
-    this._downloadSource(source, tmpfile, function(err, stdout, stderr) {
-      if(err && err.killed)
-        callback(err, false, null)
-      else
-        checkSourceExists(tmpfile)
-    })
+    if(!fs.exists(tmpfile)) {
+      this._downloadSource(source, tmpfile, function(err, stdout, stderr) {
+        if(err && err.killed)
+          callback(err, false, null)
+        else
+          checkSourceExists(tmpfile)
+      })
+    } else {
+      this.logger.log('Local Source already exists, not downloading again')
+      callback(null, true, tmpfile)
+    }
   } else {
     checkSourceExists(source)
   }
@@ -231,21 +236,24 @@ ImageMagick.prototype._convert = function(_command, params, callback) {
     , self   = this
     , size   = params.size || params.crop.split('+')[0]
     , pathHashString
-    , tmpPath
+    , srcTmpPath
+    , destTmpPath
+
+    srcTmpPath = this._createTmpPath(source)
 
     pathHashString = source + ':' + size
 
     if(params.crop)
       pathHashString += ':' + params.crop
 
-    tmpPath = this._createTmpPath(pathHashString)
+    destTmpPath = this._createTmpPath(pathHashString)
     
   this._checkSizeLimit(params.size)
-  this._localizeSource(source, tmpPath, function(err, exists, localizedSource) {
+  this._localizeSource(source, srcTmpPath, function(err, exists, localizedSource) {
     if(err && !exists)
       return callback && callback(err, null, null)
 
-    self._getTempfile(localizedSource, tmpPath, function(tmpfile) {
+    self._getTempfile(localizedSource, destTmpPath, function(tmpfile) {
       var command = "convert '" + localizedSource + "' " + _command + " '" + tmpfile + "'"
 
       if(!exists)

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -199,7 +199,7 @@ ImageMagick.prototype._checkSizeLimit = function(size) {
 }
 
 ImageMagick.prototype._convert = function(_command, params, callback) {
-  var source = decodeURIComponent(params.url)
+  var source = params.url
     , self   = this
     , size   = params.size || params.crop.split('+')[0]
 

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -142,7 +142,21 @@ ImageMagick.prototype._createTmpPath = function(rand) {
 
   digest = shasum.digest('hex')
 
-  return this.config.tmpPathRoot + '/' + digest.slice(0, 3) + '/' + digest.slice(3, 6) + '/' + digest.slice(6, 9) + '/' + digest.slice(9, 12) + '/' + digest.slice(12, 15)
+  return this.config.tmpPathRoot +
+         '/' + digest.slice(0, 3) +
+         '/' + digest.slice(3, 6) +
+         '/' + digest.slice(6, 9) +
+         '/' + digest.slice(9, 12) +
+         '/' + digest.slice(12, 15) +
+         '/' + digest.slice(15, 18) +
+         '/' + digest.slice(18, 21) +
+         '/' + digest.slice(21, 24) +
+         '/' + digest.slice(24, 27) +
+         '/' + digest.slice(27, 30) +
+         '/' + digest.slice(30, 33) +
+         '/' + digest.slice(33, 36) +
+         '/' + digest.slice(36, 39) +
+         '/' + digest.slice(39) +
 }
 
 ImageMagick.prototype._downloadSource = function(source, target, callback) {

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -180,7 +180,7 @@ ImageMagick.prototype._localizeSource = function(source, tmpPath, callback) {
 
     fs.exists(tmpfile, function(exists) {
       if(exists) {
-        self.logger.log('Local source already exists, not downloading again')
+        self.logger.log('Local source already exists at ' + tmpfile + ', not downloading again')
         callback(null, true, tmpfile)
       } else {
         self._downloadSource(source, tmpfile, function(err, stdout, stderr) {
@@ -259,13 +259,21 @@ ImageMagick.prototype._convert = function(_command, params, callback) {
       return callback && callback(err, null, null)
 
     self._getTempfile(localizedSource, destTmpPath, function(tmpfile) {
-      var command = "convert '" + localizedSource + "' " + _command + " '" + tmpfile + "'"
-
-      if(!exists)
-        command = self._getFallbackImageCommand(size, tmpfile)
-
-      self.execute(command, { timeout: self.config.timeouts.convert }, function (err, stdout, stderr) {
-        callback && callback(err, tmpfile)
+      fs.exists(tmpfile, function(tmpFileExists) {
+        if(tmpFileExists) {
+          self.logger.log('Converted file already exists. Skipping convert')
+          callback(null, tmpfile)
+        } else {
+          self.logger.log('Converted file does not exist. Converting...')
+          var command = "convert '" + localizedSource + "' " + _command + " '" + tmpfile + "'"
+    
+          if(!exists)
+            command = self._getFallbackImageCommand(size, tmpfile)
+    
+          self.execute(command, { timeout: self.config.timeouts.convert }, function (err, stdout, stderr) {
+            callback && callback(err, tmpfile)
+          })
+        }
       })
     })
   })

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -165,6 +165,8 @@ ImageMagick.prototype._downloadSource = function(source, target, callback) {
 }
 
 ImageMagick.prototype._localizeSource = function(source, tmpPath, callback) {
+  var self = this
+
   this.logger.log('Localizing source')
 
   var checkSourceExists = function(_path) {
@@ -176,17 +178,20 @@ ImageMagick.prototype._localizeSource = function(source, tmpPath, callback) {
   if(source.indexOf("http") == 0) {
     var tmpfile = ImageMagick.Templates.get('tmpPath', { dir: tmpPath, file: path.basename(source, path.extname(source)) + '.src' })
 
-    if(!fs.exists(tmpfile)) {
-      this._downloadSource(source, tmpfile, function(err, stdout, stderr) {
-        if(err && err.killed)
-          callback(err, false, null)
-        else
-          checkSourceExists(tmpfile)
-      })
-    } else {
-      this.logger.log('Local Source already exists, not downloading again')
-      callback(null, true, tmpfile)
-    }
+    fs.exists(tmpfile, function(exists) {
+      if(exists) {
+        self.logger.log('Local source already exists, not downloading again')
+        callback(null, true, tmpfile)
+      } else {
+        self._downloadSource(source, tmpfile, function(err, stdout, stderr) {
+          if(err && err.killed)
+            callback(err, false, null)
+          else
+            checkSourceExists(tmpfile)
+        })
+      }
+    });
+
   } else {
     checkSourceExists(source)
   }

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -132,10 +132,6 @@ ImageMagick.prototype._scaleCropInfo = function(cropValue, cropSourceSize, sourc
   return [[scaledCropInfo[0], scaledCropInfo[1]].join('x'), scaledCropInfo[2], scaledCropInfo[3]].join('+')
 }
 
-ImageMagick.prototype._random = function(number) {
-  return parseInt(Math.random() * number)
-}
-
 ImageMagick.prototype._createTmpPath = function(rand) {
   var shasum = crypto.createHash('sha1')
     , digest
@@ -154,7 +150,7 @@ ImageMagick.prototype._downloadSource = function(source, target, callback) {
   this.execute(ImageMagick.Templates.get('downloadCmd', {source: source, target: target}), { timeout: this.config.timeouts.download }, callback)
 }
 
-ImageMagick.prototype._localizeSource = function(source, callback) {
+ImageMagick.prototype._localizeSource = function(source, tmpPath, callback) {
   this.logger.log('Localizing source')
 
   var checkSourceExists = function(_path) {
@@ -164,7 +160,7 @@ ImageMagick.prototype._localizeSource = function(source, callback) {
   }
 
   if(source.indexOf("http") == 0) {
-    var tmpfile = ImageMagick.Templates.get('tmpPath', { dir: this._createTmpPath(), file: this._random(9999) })
+    var tmpfile = ImageMagick.Templates.get('tmpPath', { dir: tmpPath, file: path.basename(source, path.extname(source)) + '.src' })
 
     this._downloadSource(source, tmpfile, function(err, stdout, stderr) {
       if(err && err.killed)
@@ -177,12 +173,13 @@ ImageMagick.prototype._localizeSource = function(source, callback) {
   }
 }
 
-ImageMagick.prototype._getTempfile = function(source, callback) {
+ImageMagick.prototype._getTempfile = function(source, tmpPath, callback) {
   var self = this
-    , tmpPath     = this._createTmpPath()
 
   this._getMimeType(source, function(mimeType) {
-    var tmpfile = ImageMagick.Templates.get('tmpPath', { dir: tmpPath, file: self._random(9999) + '.' + mimeType })
+    var dir;
+
+    var tmpfile = ImageMagick.Templates.get('tmpPath', { dir: tmpPath, file: path.basename(source, path.extname(source))  + '-converted.' + mimeType })
     self.execute("mkdir -p " + path.dirname(tmpfile), {}, function() { callback(tmpfile) })
   })
 }
@@ -219,14 +216,23 @@ ImageMagick.prototype._convert = function(_command, params, callback) {
   var source = params.url
     , self   = this
     , size   = params.size || params.crop.split('+')[0]
+    , pathHashString
+    , tmpPath
 
+    pathHashString = source + ':' + size
+
+    if(params.crop)
+      pathHashString += ':' + params.crop
+
+    tmpPath = this._createTmpPath(pathHashString)
+    
   this._checkSizeLimit(params.size)
-  this._localizeSource(source, function(err, exists, localizedSource) {
+  this._localizeSource(source, tmpPath, function(err, exists, localizedSource) {
     if(err && !exists)
       return callback && callback(err, null, null)
 
-    self._getTempfile(localizedSource, function(tmpfile) {
-      var command = "convert '" + localizedSource + "' " + _command + " " + tmpfile
+    self._getTempfile(localizedSource, tmpPath, function(tmpfile) {
+      var command = "convert '" + localizedSource + "' " + _command + " '" + tmpfile + "'"
 
       if(!exists)
         command = self._getFallbackImageCommand(size, tmpfile)

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -146,7 +146,7 @@ ImageMagick.prototype._createTmpPath = function(rand) {
 
   digest = shasum.digest('hex')
 
-  return this.config.tmpPathRoot + '/' + digest.slice(0, 4) + '/' + digest.slice(4, 8) + '/' + digest.slice(8, 12) + '/' + digest.slice(12, 16) + '/' + digest.slice(16, 20)
+  return this.config.tmpPathRoot + '/' + digest.slice(0, 3) + '/' + digest.slice(3, 6) + '/' + digest.slice(6, 9) + '/' + digest.slice(9, 12) + '/' + digest.slice(12, 15)
 }
 
 ImageMagick.prototype._downloadSource = function(source, target, callback) {

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -1,5 +1,6 @@
 var exec     = require('child_process').exec
   , path     = require('path')
+  , fs       = require('fs')
   , Identify = require('identify.js')
 
 var ImageMagick = module.exports = function(config, logger) {
@@ -142,7 +143,7 @@ ImageMagick.prototype._localizeSource = function(source, callback) {
   this.logger.log('Localizing source')
 
   var checkSourceExists = function(_path) {
-    path.exists(_path, function(exists) {
+    fs.exists(_path, function(exists) {
       callback(null, exists, _path)
     })
   }

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -1,6 +1,7 @@
 var exec     = require('child_process').exec
   , path     = require('path')
   , fs       = require('fs')
+  , crypto   = require('crypto')
   , Identify = require('identify.js')
 
 var ImageMagick = module.exports = function(config, logger) {
@@ -14,7 +15,7 @@ var ImageMagick = module.exports = function(config, logger) {
 }
 
 ImageMagick.Templates = {
-  tmpPath: "%{tmpPathRoot}/%{dir}/%{file}",
+  tmpPath: "%{dir}/%{file}",
 
   downloadCmd: "curl --create-dirs -sf '%{source}' -o '%{target}'",
   identifyCmd: "identify -format %m '%{file}'",
@@ -135,6 +136,19 @@ ImageMagick.prototype._random = function(number) {
   return parseInt(Math.random() * number)
 }
 
+ImageMagick.prototype._createTmpPath = function(rand) {
+  var shasum = crypto.createHash('sha1')
+    , digest
+
+  rand = rand || Date.now()
+
+  shasum.update(rand.toString())
+
+  digest = shasum.digest('hex')
+
+  return this.config.tmpPathRoot + '/' + digest.slice(0, 4) + '/' + digest.slice(4, 8) + '/' + digest.slice(8, 12) + '/' + digest.slice(12, 16) + '/' + digest.slice(16, 20)
+}
+
 ImageMagick.prototype._downloadSource = function(source, target, callback) {
   this.logger.log('Downloading source')
   this.execute(ImageMagick.Templates.get('downloadCmd', {source: source, target: target}), { timeout: this.config.timeouts.download }, callback)
@@ -150,7 +164,7 @@ ImageMagick.prototype._localizeSource = function(source, callback) {
   }
 
   if(source.indexOf("http") == 0) {
-    var tmpfile = ImageMagick.Templates.get('tmpPath', { tmpPathRoot: this.config.tmpPathRoot, dir: Date.now(), file: this._random(9999) })
+    var tmpfile = ImageMagick.Templates.get('tmpPath', { dir: this._createTmpPath(), file: this._random(9999) })
 
     this._downloadSource(source, tmpfile, function(err, stdout, stderr) {
       if(err && err.killed)
@@ -165,10 +179,10 @@ ImageMagick.prototype._localizeSource = function(source, callback) {
 
 ImageMagick.prototype._getTempfile = function(source, callback) {
   var self = this
-    , tmpPathRoot = this.config.tmpPathRoot
+    , tmpPath     = this._createTmpPath()
 
   this._getMimeType(source, function(mimeType) {
-    var tmpfile = ImageMagick.Templates.get('tmpPath', { tmpPathRoot: tmpPathRoot, dir: Date.now(), file: self._random(9999) + '.' + mimeType })
+    var tmpfile = ImageMagick.Templates.get('tmpPath', { dir: tmpPath, file: self._random(9999) + '.' + mimeType })
     self.execute("mkdir -p " + path.dirname(tmpfile), {}, function() { callback(tmpfile) })
   })
 }

--- a/lib/image-magick.js
+++ b/lib/image-magick.js
@@ -246,10 +246,7 @@ ImageMagick.prototype._convert = function(_command, params, callback) {
 
     srcTmpPath = this._createTmpPath(source)
 
-    pathHashString = source + ':' + size
-
-    if(params.crop)
-      pathHashString += ':' + params.crop
+    pathHashString = source + ':' + _command
 
     destTmpPath = this._createTmpPath(pathHashString)
     

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -138,7 +138,7 @@ RequestHandler.prototype._afterResize = function(err, path, res, callback) {
     res.contentType(path.replace(/\?(.*)/, ""))
     res.sendfile(path, { maxAge: oneYear }, function() {
       self.logger.log('File sent')
-      self.deleteTempfile(path)
+//      self.deleteTempfile(path)
       callback && callback()
     })
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "mocha": "0.10.x",
-    "should": "0.5.1"
+    "should": "1.1.x"
   }
 }

--- a/test/image-magick.js
+++ b/test/image-magick.js
@@ -6,7 +6,7 @@ const ImageMagick    = require("../lib/image-magick")
     , localImage     = process.cwd() + "/test/fixtures/test.jpg"
     , testTmpRoot    = process.cwd() + "/test/tmp"
     , clearTmpFolder = function() {
-        exec('rm -rf ' + testTmpRoot + "/*")
+//        exec('rm -rf ' + testTmpRoot + "/*")
         exec('rm ' + process.cwd() + "/../tmp/*")
       }
 

--- a/test/image-magick.js
+++ b/test/image-magick.js
@@ -6,7 +6,7 @@ const ImageMagick    = require("../lib/image-magick")
     , localImage     = process.cwd() + "/test/fixtures/test.jpg"
     , testTmpRoot    = process.cwd() + "/test/tmp"
     , clearTmpFolder = function() {
-//        exec('rm -rf ' + testTmpRoot + "/*")
+        exec('rm -rf ' + testTmpRoot + "/*")
         exec('rm ' + process.cwd() + "/../tmp/*")
       }
 

--- a/test/image-magick.js
+++ b/test/image-magick.js
@@ -4,8 +4,9 @@ const ImageMagick    = require("../lib/image-magick")
     , frenchImage    = 'http://blog-fr.dawanda.com/wp-content/uploads/2012/01/Capture-d’écran-2012-01-19-à-11.27.07.png'
     , bigImage       = 'http://s31.dawandastatic.com/PressReleaseItem/0/818/1264780823-785.jpg'
     , localImage     = process.cwd() + "/test/fixtures/test.jpg"
+    , testTmpRoot    = process.cwd() + "/test/tmp"
     , clearTmpFolder = function() {
-        exec('rm ' + process.cwd() + "/test/tmp/*")
+        exec('rm -rf ' + testTmpRoot + "/*")
         exec('rm ' + process.cwd() + "/../tmp/*")
       }
 
@@ -31,7 +32,7 @@ describe('ImageMagick', function() {
   }
 
   beforeEach(function() {
-    imageMagick = new ImageMagick({})
+    imageMagick = new ImageMagick({"tmpPathRoot": testTmpRoot})
   })
 
   after(function() {
@@ -88,7 +89,7 @@ describe('ImageMagick', function() {
 
       describe('with configured timeouts for convert', function() {
         beforeEach(function() {
-          imageMagick = new ImageMagick({ timeouts: { convert: 100 } })
+          imageMagick = new ImageMagick({ timeouts: { convert: 100 }, tmpPathRoot: testTmpRoot })
         })
 
         it('resizes images when size is passed', function(done) {
@@ -101,7 +102,7 @@ describe('ImageMagick', function() {
 
       describe('with configured timeouts for resize', function() {
         beforeEach(function() {
-          imageMagick = new ImageMagick({ timeouts: { download: 100 } })
+          imageMagick = new ImageMagick({ timeouts: { download: 100 }, tmpPathRoot: testTmpRoot })
         })
 
         it('resizes images when size is passed', function(done) {
@@ -115,7 +116,7 @@ describe('ImageMagick', function() {
 
     describe('with size limit', function() {
       beforeEach(function() {
-        imageMagick = new ImageMagick({ imageSizeLimit: 1000 })
+        imageMagick = new ImageMagick({ imageSizeLimit: 1000, tmpPathRoot: testTmpRoot })
       })
 
       it('works when size is below limit', function(done) {

--- a/test/image-magick.js
+++ b/test/image-magick.js
@@ -77,6 +77,10 @@ describe('ImageMagick', function() {
     })
 
     describe('with a big image', function() {
+      beforeEach(function () {
+        clearTmpFolder()
+      })
+
       describe('without configured timeouts', function() {
         it('resizes images when size is passed', function(done) {
           resize({ size: '640x480', url: bigImage }, function(err, stdout, stderr) {
@@ -100,7 +104,7 @@ describe('ImageMagick', function() {
         })
       })
 
-      describe('with configured timeouts for resize', function() {
+      describe('with configured timeouts for download', function() {
         beforeEach(function() {
           imageMagick = new ImageMagick({ timeouts: { download: 100 }, tmpPathRoot: testTmpRoot })
         })


### PR DESCRIPTION
Do not decode url param a second time before converting. Causes normalization to be more painful than it needs to be, and the url is already decoded at this point.

Normalization is necessary because cURL does not do it itself.
