### PR TITLE
res.contentType fix

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -152,7 +152,7 @@ RequestHandler.prototype._afterResize = function(err, path, res, callback) {
   } else {
     this.logger.log('Sending processed image')
 
-    res.contentType(path.replace(/\?(.*)/, ""))
+    res.contentType(path.match(/\.[0-9a-z]+$/i)[0])
     res.sendfile(path, { maxAge: oneYear }, function() {
       self.logger.log('File sent')
 


### PR DESCRIPTION
Minor edit to content type request setting that uses extension instead of the full path as mime lookup seems to like this best.

Looking into the mime module and connect, it should be able to handle the full path, but for some reason it likes just the extension like ".jpg" better.
